### PR TITLE
Fix "Prefer `format()` over string interpolation operator" issue

### DIFF
--- a/settings.py
+++ b/settings.py
@@ -143,8 +143,8 @@ STATICFILES_FINDERS = (
 
 STATIC_URL = '/static/'
 
-print 'BASE_DIR = %s' %BASE_DIR
-print 'PROJECT_ROOT = %s' %PROJECT_ROOT
+print 'BASE_DIR = {0!s}'.format(BASE_DIR)
+print 'PROJECT_ROOT = {0!s}'.format(PROJECT_ROOT)
 
 logging.info('12 out of- settings.py')
 


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Prefer `format()` over string interpolation operator](https://www.quantifiedcode.com/app/issue_class/4ACGxFj1)
Issue details: [https://www.quantifiedcode.com/app/project/gh:puruckertom:tom-purucker?groups=code_patterns/%3A4ACGxFj1](https://www.quantifiedcode.com/app/project/gh:puruckertom:tom-purucker?groups=code_patterns/%3A4ACGxFj1)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Legal note: We won't claim any copyrights on the code changes.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)